### PR TITLE
fix: error message in login form not showing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,8 @@ AllCops:
 
   DisplayCopNames: true
 
+  NewCops: enable
+
 Layout/LineLength:
   Max: 120
 Metrics/MethodLength:
@@ -25,7 +27,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
-  ExcludedMethods: ['describe']
+  IgnoredMethods: ['describe']
   Max: 50
 
 Style/Documentation:

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,16 +30,8 @@
         <div class="container px-0 overflow-auto h-100" id="subcontainer">
       <% end %>
 
-        <%= yield %>
+      <%= yield %>
 
-        <% if action_name != 'show' %>
-          <% flash.each do |m_type, msg| %>
-            <div class="alert alert-<%= m_type %> w-75 mx-auto text-center mt-3">
-              <%= msg %>
-            </div>
-          <% end %>
-        <% end %>
-      
       </div>
     </div>
   </body>

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -7,4 +7,10 @@
       <li><%= msg %></li>
     <% end %>
   </ul>
+<% else %>
+  <% flash.each do |m_type, msg| %>
+    <div class="alert alert-<%= m_type %> w-75 mx-auto text-center mt-3">
+      <%= msg %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -1,10 +1,13 @@
 <% provide(:title, 'Login') %>
 
-<div class="d-flex flex-column h-75 justify-content-between mt-5 mx-3">
-  <%= form_with scope: :session, url: login_path, html: { class: "" } do |f| %>
+<div class="d-flex flex-column h-75 mt-5 mx-3">
+  <%= form_with scope: :session, url: login_path, local: true, html: { class: "" } do |f| %>
     <%= f.text_field :name, class: "form-control", placeholder: "Name" %>
 
-    <%= f.submit 'Log in', class: "btn btn-primary my-4 mx-auto d-block" %>
+    <%= f.submit 'Log in', class: "btn btn-primary mt-4 mb-2 mx-auto d-block" %>
   <% end %>
-  <p class="">New user? <%= link_to  'Sign up now!', signup_path %></p>
+
+  <%= render  partial: 'shared/form_errors', locals: { model: @user } %>
+
 </div>
+<p class="mx-3" style="position: absolute; top: 80%">New user? <%= link_to  'Sign up now!', signup_path %></p>

--- a/spec/features/user_feature_spec.rb
+++ b/spec/features/user_feature_spec.rb
@@ -24,12 +24,23 @@ RSpec.feature 'UserFeatures', type: :feature do
       expect(page).to have_content 'Account created successfully!'
     end
 
-    it 'can log in a user' do
-      create_user
-      visit login_path
-      fill_in 'Name', with: 'User01'
-      click_button 'Log in'
-      expect(page).to have_content 'you are logged in!'
+    context 'login form' do
+      setup do
+        create_user
+        visit login_path
+      end
+
+      it 'can log in a user' do
+        fill_in 'Name', with: 'User01'
+        click_button 'Log in'
+        expect(page).to have_content 'you are logged in!'
+      end
+
+      it 'can display login error message' do
+        fill_in 'Name', with: 'X'
+        click_button 'Log in'
+        expect(page).to have_content "User doesn't exist, please sign up"
+      end
     end
   end
 


### PR DESCRIPTION
## Issue
Warning message isn't displaying on unsuccessful login

## Screenshots
![Screenshot_20230217_155022](https://user-images.githubusercontent.com/42077060/219800554-dfc60867-75d6-446d-9670-b5294c568d22.png)

## Procedure
Error is in the form, in the use of form_with.
Explanation:
form_with by default creates the form with the attribute data-remote set to 'true'. Which processes an ajax, JS response instead of a normal HTML response.
So we have 2 options:
1) Use the attribute <local: true>, which changes the attribute data-remote to false.
2) Use form_for, which doesn't activate the data_remote, or, better said: has that attribute set to false by default.

## Test
Create model or controller tests accordingly
- User/login form

